### PR TITLE
(#34) Simplifies the CFPW page.

### DIFF
--- a/cfpw.md
+++ b/cfpw.md
@@ -7,44 +7,37 @@ title: "Call for Papers & Workshops"
 
 ## Call for Papers
 
-OzLockCon aims to be the first conference in Australia catering specifically to
-physical security research and offensive | defensive techniques.
+OzLockCon will be the first conference in Australia specifically on physical security research and offensive/defensive techniques.
 
-We aim to bring the openness and desire to share information found in the
-*information security industry* to a different crowd.
+We aim to bring the openness to share information found in conferences of the information security industry to a different crowd.
 
 ### Submissions
 
-Please fill out the respective Google Form if you wish to submit a proposal for
-either a talk or workshop.
+Please fill out the Google forms below to submit talk or workshop proposal.
 
 &rarr; **[Talks](https://docs.google.com/forms/d/e/1FAIpQLScnTJSsOE7BQQhB9h-7vX8-ZSq3yEYInoZ1oaCx449BjGocjQ/viewform)**
 
 &rarr; **[Workshops](https://docs.google.com/forms/d/e/1FAIpQLSek7UopUnAegE6837dtcE-PcPeQDq_yUSOFvc7DE_nArDE0Vw/viewform)**
 
-<small>The call will close <strong>April 30th 2017</strong>.</small>
+<small>Submissions close <strong>April 30th 2017</strong>.</small>
 
 ### Talk topics
 
-We are looking for presenters to talk on a wide range of topics in an informal
-environment amongst their peers.
+We are looking for presenters to talk on a range of topics in an informal environment amongst their peers.
 
-Besides the following topics, in [the hacker-spirit of things](/faq#who-are-you)
-we’d love submissions that hold great **technical detail** and/or provide a
-**critical view** at an aspect or technology within the domain of physical
-security.
+In [the hacker-spirit of things](/faq#who-are-you) we’re after submissions that hold great **technical detail** and/or provide a **critical view** at an aspect or technology *within* the domain of physical security.
 
-So, some topic ideas—
+So, some topic ideas:
 
 * picking techniques
-* bypass techniques and tools
+* bypass techniques & tools
 * impressioning techniques
 * digital lock manipulation
-* decoding locks
+* decoding attacks
 * safe manipulation
 * the locksport community and our hobby
 * historical/antique locks
-* privilege escalation attacks against lock systems
+* privilege escalation attacks
 * key duplication
 * alarm system attacks
 * building access control systems
@@ -56,26 +49,20 @@ So, some topic ideas—
 * improving physical security
 * 'tamper-evident' seals
 * making/hacking challenge locks
-* legal aspects of locksport in AU/NZ
+* legal aspects of locksport in Oceania
 * physical security in red teaming/pen. testing
-* radio security (eg. mobile, pagers, CB radio)
-* RFID/Magstripe/Smartcard security
+* radio security (eg. mobile, pagers, <abbr title="Citizens Band">CB</abbr> radio)
+* <abbr title="Radio-frequency Identification">RFID</abbr>/Magstripe/Smartcard security
 * social engineering
 
-<small>If you think your topic might still be of interest but isn't explicitly
-listed here, please submit anyway and we will be happy to review it regardless.
-</small>
+<small>If your topic isn't listed here but relates to physical security, please submit anyway and we will be happy to review it.</small>
+
+<small>Submissions that have nothing to do with physical security will be rejected.</small>
 
 ## Call for Workshops
 
-In addition to the traditional 'talks' that will occur (like at most other
-conferences) OzLockCon aims to have a large amount of hands-on and interactive
-content.
+In addition to traditional 'talks' (like at most other conferences), OzLockCon will have hands-on content.
 
-We are looking for people to run workshops which can run anywhere between an
-hour to the full course of the conference.
+We are looking for people to run workshops. These can run anywhere between an hour to the full course of the conference.
 
-<small>If you require financial assistance in order to run such a workshop (for
-example, to purchase a large number of key-blanks and files to teach
-impressioning techniques) please state so in the CFP and we'll attempt to make
-arrangements.</small>
+<small>If you require financial assistance in order to run such a workshop (eg. to purchase a large number of key blanks and files to teach impressioning techniques) please let us know in your submission and we'll try to help you out.</small>


### PR DESCRIPTION
Minor simplification of the CFPW page:

- from 343 to 320 words
- adds a few missing `abbr` defs.
- went from ~year 13 to yr 12 in reading difficulty
- went from just under 2 mins to 1.5 mins est. reading time
- culled a bunch of complex words here and there. 